### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Projects related to SPL, Token 2022, and the various NFT standards
 | McBurnJS               | [McDegensDAO](https://twitter.com/McDegensDAO)                                      | Yes                  | <a href="https://github.com/McDegens-DAO/mcburn-js/" target="_blank">View</a>              |
 | cNFT Spam Filter       | [Solarnius](https://twitter.com/solarnius)                                          | Yes                  | <a href="https://github.com/filtoor/cnft-spam-filter" target="_blank">View</a>             |
 | Underdog SDK           | [Underdog](https://twitter.com/backanunderdog)                                      | No                   | <a href="https://github.com/UnderdogProtocol/js" target="_blank">View</a>                  |
+| MintMe                 | [Mintme](https://x.com/mintme_dev)                                                  | Yes                  | <a href="https://github.com/mintme-dev/mintme-widget" target="_blank">View</a>             |
+
 
 <br>
 


### PR DESCRIPTION
Hi,

I’d like to propose adding MintMe SDK to the awesome-solana-oss list under 🪙 Token & NFT Tooling.

[Mintme](https://github.com/mintme-dev/mintme-widget)

JavaScript/TypeScript SDK for creating and managing SPL tokens with Metaplex metadata, revoking authorities, and handling optional commissions.

Includes a lightweight React widget accessible on mintme.dev for direct token interaction.

SDK can be integrated into Node.js or browser environments, making it easy for developers to build their own dApps to mint tokens.